### PR TITLE
SD-1188: Updating Default Cache TTL Time to One Month

### DIFF
--- a/Cache/Backend.php
+++ b/Cache/Backend.php
@@ -42,7 +42,7 @@ class Zend_Cache_Backend
      * @var array directives
      */
     protected $_directives = array(
-        'lifetime' => 2628288,
+        'lifetime' => 2592000,
         'logging'  => false,
         'logger'   => null
     );

--- a/Cache/Backend.php
+++ b/Cache/Backend.php
@@ -42,7 +42,7 @@ class Zend_Cache_Backend
      * @var array directives
      */
     protected $_directives = array(
-        'lifetime' => 3600,
+        'lifetime' => 2628288,
         'logging'  => false,
         'logger'   => null
     );


### PR DESCRIPTION
## Description

This PR addresses the issue where the default expiration of a key in Redis is set to 60 seconds when we need it to be set for much longer, as documented in the related ticket to 1 month. As a submodule dependency of `cdins/insuredapp` this will affect all class instances extending the `Zend_Cache_Backend` class.

Note that this property change in `Cache/Backend.php` affects `getLifetime()` function, and will return this new value of 1 month instead of the previous default of 1 hour.
